### PR TITLE
Use a flag to avoid re-creating the TaskExecutingServer

### DIFF
--- a/src/NetEscapades.AspNetCore.StartupTasks.Sources/ServiceCollectionExtensions.cs
+++ b/src/NetEscapades.AspNetCore.StartupTasks.Sources/ServiceCollectionExtensions.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.Insert(index, decoratorDescriptor);
 
             services.Remove(serverDescriptor);
-            
+
             _alreadyAddedDecorator = true;
 
             return services;

--- a/src/NetEscapades.AspNetCore.StartupTasks.Sources/ServiceCollectionExtensions.cs
+++ b/src/NetEscapades.AspNetCore.StartupTasks.Sources/ServiceCollectionExtensions.cs
@@ -10,6 +10,8 @@ namespace Microsoft.Extensions.DependencyInjection
     /// </summary>
     public static class ServiceCollectionExtensions
     {
+        private static bool _alreadyAddedDecorator;
+
         /// <summary>
         /// Add an <see cref="IStartupTask"/> registration for the given type.
         /// </summary>
@@ -24,8 +26,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
         private static IServiceCollection AddTaskExecutingServer(this IServiceCollection services)
         {
-            var decoratorType = typeof(TaskExecutingServer);
-            if (services.Any(service => service.ImplementationType == decoratorType))
+            if (_alreadyAddedDecorator)
             {
                 // We've already decorated the IServer (make this call idempotent)
                 return services;
@@ -38,7 +39,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 throw new Exception("Could not find any registered services for type IServer. IStartupTask requires using an IServer");
             }
 
-            var decoratorDescriptor = CreateDecoratorDescriptor(serverDescriptor, decoratorType);
+            var decoratorDescriptor = CreateDecoratorDescriptor(serverDescriptor, typeof(TaskExecutingServer));
 
             var index = services.IndexOf(serverDescriptor);
 

--- a/src/NetEscapades.AspNetCore.StartupTasks.Sources/ServiceCollectionExtensions.cs
+++ b/src/NetEscapades.AspNetCore.StartupTasks.Sources/ServiceCollectionExtensions.cs
@@ -47,6 +47,8 @@ namespace Microsoft.Extensions.DependencyInjection
             services.Insert(index, decoratorDescriptor);
 
             services.Remove(serverDescriptor);
+            
+            _alreadyAddedDecorator = true;
 
             return services;
         }


### PR DESCRIPTION
Solution to issue #2 

This not only saves a few CPU cycles, avoiding the loop of all the services, it also simplifies the code a bit.